### PR TITLE
#157694795 Fixes accounts tests

### DIFF
--- a/hc/accounts/tests/test_check_token.py
+++ b/hc/accounts/tests/test_check_token.py
@@ -21,8 +21,17 @@ class CheckTokenTestCase(BaseTestCase):
         self.profile.refresh_from_db()
         self.assertEqual(self.profile.token, "")
 
-    ### Login and test it redirects already logged in
+        # Login and test it redirects already logged in
+        self.assertEqual(r.status_code, 302)
 
-    ### Login with a bad token and check that it redirects
+        # Login with a bad token and check that it redirects
 
-    ### Any other tests?
+    def test_login_bad_token_redirects(self):
+        # import ipdb;
+        # ipdb.set_trace()
+        r = self.client.post(
+            "/accounts/check_token/michael/secret-token/")
+        print("dfghj", r.status_code)
+        self.assertEqual(r.status_code, 302)
+
+        # Any other tests?

--- a/hc/accounts/tests/test_login.py
+++ b/hc/accounts/tests/test_login.py
@@ -9,6 +9,7 @@ class LoginTestCase(TestCase):
     def test_it_sends_link(self):
         check = Check()
         check.save()
+        count_before = User.objects.count()
 
         session = self.client.session
         session["welcome_code"] = str(check.code)
@@ -19,19 +20,24 @@ class LoginTestCase(TestCase):
         r = self.client.post("/accounts/login/", form)
         assert r.status_code == 302
 
-        ### Assert that a user was created
+        # Assert that a user was created
+        User.objects.get(email=form["email"])
+        count_after = User.objects.count()
+        self.assertEqual(count_after, count_before + 1)
 
         # And email sent
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].subject, 'Log in to healthchecks.io')
-        ### Assert contents of the email body
+        # Assert contents of the email body
+        self.assertIn('To log into healthchecks.io', mail.outbox[0].body)
 
-        ### Assert that check is associated with the new user
-
+        # Assert that check is associated with the new user
+        new = Check.objects.get(code=check.code)
+        self.assertTrue(new.user)
+        
     def test_it_pops_bad_link_from_session(self):
         self.client.session["bad_link"] = True
         self.client.get("/accounts/login/")
         assert "bad_link" not in self.client.session
 
-        ### Any other tests?
-
+        # Any other tests?

--- a/hc/accounts/tests/test_switch_team.py
+++ b/hc/accounts/tests/test_switch_team.py
@@ -23,6 +23,7 @@ class SwitchTeamTestCase(BaseTestCase):
         url = "/accounts/switch_team/%s/" % self.alice.username
         r = self.client.get(url)
         ### Assert the expected error code
+        self.assertEqual(r.status_code, 403)
 
     def test_it_switches_to_own_team(self):
         self.client.login(username="alice@example.org", password="password")
@@ -30,3 +31,4 @@ class SwitchTeamTestCase(BaseTestCase):
         url = "/accounts/switch_team/%s/" % self.alice.username
         r = self.client.get(url, follow=True)
         ### Assert the expected error code
+        self.assertEqual(r.status_code, 200)

--- a/hc/accounts/tests/test_switch_team.py
+++ b/hc/accounts/tests/test_switch_team.py
@@ -14,6 +14,7 @@ class SwitchTeamTestCase(BaseTestCase):
         r = self.client.get(url, follow=True)
 
         ### Assert the contents of r
+        self.assertEqual(r.status_code, 200)
 
 
     def test_it_checks_team_membership(self):

--- a/hc/accounts/tests/test_team_access_middleware.py
+++ b/hc/accounts/tests/test_team_access_middleware.py
@@ -15,3 +15,5 @@ class TeamAccessMiddlewareTestCase(TestCase):
         self.assertEqual(r.status_code, 200)
 
         ### Assert the new Profile objects count
+        profile = list(Profile.objects.all())
+        assert profile

--- a/hc/settings.py
+++ b/hc/settings.py
@@ -121,6 +121,7 @@ USE_L10N = True
 USE_TZ = True
 
 SITE_ROOT = "http://localhost:8000"
+SITE_NAME = "healthchecks.io"
 PING_ENDPOINT = SITE_ROOT + "/ping/"
 PING_EMAIL_DOMAIN = HOST
 STATIC_URL = '/static/'


### PR DESCRIPTION
**What does this PR do?**
Fixing the accounts tests

**Description of Task to be completed?**
The following tests are passing:

```bash
$ hc/accounts/tests/test_check_token.py test_it_redirects
```
```bash
$ hc/accounts/tests/test_check_token.py test_login_bad_token_redirects
```
```bash
$ hc/accounts/tests/test_login.py test_it_sends_link
```
```bash
$ hc/accounts/tests/test_profile.py test_it_sends_report
```
```bash
$ hc/accounts/tests/test_profile.py test_it_adds_team_member
```
```bash
$ hc/accounts/tests/test_profile.py test_it_creates_api_key
```
```bash
$ hc/accounts/tests/test_profile.py test_it_revokes_api_key
```
```bash
$ hc/accounts/tests/test_switch_team.py test_it_switches
```
```bash
$ hc/accounts/tests/test_switch_team.py test_it_checks_team_membership
```
```bash
$ hc/accounts/tests/test_switch_team.py test_it_switches_to_own_team
```
```bash
$ hc/accounts/tests/test_team_access_middleware.py test_it_handles_missing_profile
```

**How should this be manually tested?**
After cloning the repo, cd into the project and run ```./manage.py test hc.accounts.tests```

**What are relevant pivotal tracker stories?**
```#157694795```