### PR TITLE
[Feature #157694799] unresolved issues tab 

### DIFF
--- a/hc/front/tests/test_unresolved.py
+++ b/hc/front/tests/test_unresolved.py
@@ -1,0 +1,28 @@
+from hc.api.models import Check
+from hc.test import BaseTestCase
+from datetime import timedelta as td
+from django.utils import timezone
+
+
+class UnresolvedTestCase(BaseTestCase):
+
+    def setUp(self):
+        super(UnresolvedTestCase, self).setUp()
+        self.check = Check(user=self.alice, name="Failed check")
+        self.check.save()
+
+    def test_it_works(self):
+        for email in ("alice@example.org", "bob@example.org"):
+            self.client.login(username=email, password="password")
+            r = self.client.get("/unresolved/")
+            self.assertEqual(r.status_code, 200)
+
+    def test_it_contains_failed_check(self):
+        self.check.last_ping = timezone.now() - td(days=3)
+        self.check.status = "up"
+        self.check.save()
+
+        self.client.login(username="alice@example.org", password="password")
+        r = self.client.get("/unresolved/")
+
+        self.assertContains(r, "Failed check")

--- a/hc/front/urls.py
+++ b/hc/front/urls.py
@@ -34,7 +34,7 @@ urlpatterns = [
     url(r'^checks/add/$', views.add_check, name="hc-add-check"),
     url(r'^checks/([\w-]+)/', include(check_urls)),
     url(r'^integrations/', include(channel_urls)),
-
+    url(r'^unresolved/', views.unresolved, name="hc-unresolved"),
     url(r'^docs/$', views.docs, name="hc-docs"),
     url(r'^docs/api/$', views.docs_api, name="hc-docs-api"),
     url(r'^about/$', views.about, name="hc-about"),

--- a/hc/front/views.py
+++ b/hc/front/views.py
@@ -70,9 +70,6 @@ def get_failing_checks(request):
 
 @login_required
 def unresolved(request):
-    # q = Check.objects.filter(user=request.team.user).order_by("created")
-    # checks = list(q)
-    #
     counter = Counter()
     down_tags = set()
     failing_checks = get_failing_checks(request)[0]

--- a/hc/front/views.py
+++ b/hc/front/views.py
@@ -69,15 +69,12 @@ def unresolved(request):
     down_tags = set()
     failing_checks = [check for check in checks if check.get_status() == "down"]
     for check in failing_checks:
-        status = check.get_status()
         for tag in check.tags_list():
             if tag == "":
                 continue
 
             counter[tag] += 1
-
-            if status == "down":
-                down_tags.add(tag)
+            down_tags.add(tag)
 
     ctx = {
         "page": "unresolved",

--- a/hc/front/views.py
+++ b/hc/front/views.py
@@ -54,20 +54,28 @@ def my_checks(request):
         "tags": counter.most_common(),
         "down_tags": down_tags,
         "grace_tags": grace_tags,
-        "ping_endpoint": settings.PING_ENDPOINT
+        "ping_endpoint": settings.PING_ENDPOINT,
+        "failing_count": get_failing_checks(request)[1]
     }
 
     return render(request, "front/my_checks.html", ctx)
 
 
-@login_required
-def unresolved(request):
+def get_failing_checks(request):
     q = Check.objects.filter(user=request.team.user).order_by("created")
     checks = list(q)
+    failing_checks = [check for check in checks if check.get_status() == "down"]
+    return failing_checks, len(failing_checks)
 
+
+@login_required
+def unresolved(request):
+    # q = Check.objects.filter(user=request.team.user).order_by("created")
+    # checks = list(q)
+    #
     counter = Counter()
     down_tags = set()
-    failing_checks = [check for check in checks if check.get_status() == "down"]
+    failing_checks = get_failing_checks(request)[0]
     for check in failing_checks:
         for tag in check.tags_list():
             if tag == "":
@@ -79,7 +87,7 @@ def unresolved(request):
     ctx = {
         "page": "unresolved",
         "checks": failing_checks,
-        "num_checks": len(failing_checks),
+        "failing_count": len(failing_checks),
         "now": timezone.now(),
         "tags": counter.most_common(),
         "down_tags": down_tags,
@@ -130,6 +138,9 @@ def docs(request):
         "ping_url": check.url()
     }
 
+    if request.user.is_authenticated:
+        ctx['failing_count'] = get_failing_checks(request)[1]
+
     return render(request, "front/docs.html", ctx)
 
 
@@ -147,7 +158,13 @@ def docs_api(request):
 
 
 def about(request):
-    return render(request, "front/about.html", {"page": "about"})
+    ctx = {
+        "page": "about"
+    }
+    if request.user.is_authenticated:
+        ctx['failing_count'] = get_failing_checks(request)[1]
+
+    return render(request, "front/about.html", ctx)
 
 
 @login_required
@@ -315,7 +332,8 @@ def channels(request):
         "channels": channels,
         "num_checks": num_checks,
         "enable_pushbullet": settings.PUSHBULLET_CLIENT_ID is not None,
-        "enable_pushover": settings.PUSHOVER_API_TOKEN is not None
+        "enable_pushover": settings.PUSHOVER_API_TOKEN is not None,
+        "failing_count": get_failing_checks(request)[1]
     }
     return render(request, "front/channels.html", ctx)
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -77,6 +77,14 @@
                         <a href="{% url 'hc-checks' %}">Checks</a>
                     </li>
 
+                    <li {% if page == 'unresolved' %} class="active" {% endif %}>
+                        <a href="{% url 'hc-unresolved' %}">Unresolved
+                        {% if checks %}
+                        <span class="badge badge-danger">{{ num_checks }}</span>
+                        {% endif %}
+                        </a>
+                    </li>
+
                     <li {% if page == 'channels' %} class="active" {% endif %}>
                         <a href="{% url 'hc-channels' %}">Integrations</a>
                     </li>

--- a/templates/base.html
+++ b/templates/base.html
@@ -77,10 +77,11 @@
                         <a href="{% url 'hc-checks' %}">Checks</a>
                     </li>
 
-                    <li {% if page == 'unresolved' %} class="active" {% endif %}>
+                    <li  {% if page == 'unresolved' %} class="active" {% endif %}>
                         <a href="{% url 'hc-unresolved' %}">Unresolved
-                        {% if checks %}
-                        <span class="badge badge-danger">{{ num_checks }}</span>
+                        {% if not failing_count %}
+                        {% else %}
+                        <span class="badge badge-danger">{{ failing_count }}</span>
                         {% endif %}
                         </a>
                     </li>

--- a/templates/front/unresolved.html
+++ b/templates/front/unresolved.html
@@ -1,0 +1,283 @@
+{% extends "base.html" %}
+{% load compress staticfiles %}
+
+{% block title %}Unresolved - healthchecks.io{% endblock %}
+
+
+{% block content %}
+<div class="row">
+    <div class="col-sm-12">
+        <h1>
+        {% if request.team == request.user.profile %}
+            Failing checks
+        {% else %}
+            {{ request.team.team_name }}
+        {% endif %}
+        </h1>
+    </div>
+    {% if tags %}
+    <div id="my-checks-tags" class="col-sm-12">
+        {% for tag, count in tags %}
+            {% if tag in down_tags %}
+                <button class="btn btn-danger btn-xs" data-toggle="button">{{ tag }}</button>
+            {% elif tag in grace_tags %}
+                <button class="btn btn-warning btn-xs" data-toggle="button">{{ tag }}</button>
+            {% else %}
+                <button class="btn btn-default btn-xs" data-toggle="button">{{ tag }}</button>
+            {% endif %}
+        {% endfor %}
+    </div>
+    {% endif %}
+
+</div>
+<div class="row">
+    <div class="col-sm-12">
+
+
+    {% if checks %}
+        {% include "front/my_checks_mobile.html" %}
+        {% include "front/my_checks_desktop.html" %}
+    {% else %}
+    <div class="alert alert-info">You don't have any failing checks.</div>
+    {% endif %}
+    </div>
+</div>
+
+<div id="update-name-modal" class="modal">
+    <div class="modal-dialog">
+        <form id="update-name-form" class="form-horizontal" method="post">
+            {% csrf_token %}
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal">&times;</button>
+                    <h4 class="update-timeout-title">Name and Tags</h4>
+                </div>
+                <div class="modal-body">
+                        <div class="form-group">
+                            <label for="update-name-input" class="col-sm-2 control-label">
+                                Name
+                            </label>
+                            <div class="col-sm-9">
+                                <input
+                                    id="update-name-input"
+                                    name="name"
+                                    type="text"
+                                    value="---"
+                                    placeholder="unnamed"
+                                    class="input-name form-control" />
+
+                                <span class="help-block">
+                                    Give this check a human-friendly name,
+                                    so you can easily recognize it later.
+                                </span>
+                            </div>
+                        </div>
+
+                        <div class="form-group">
+                            <label for="update-tags-input" class="col-sm-2 control-label">
+                                Tags
+                            </label>
+                            <div class="col-sm-9">
+                                <input
+                                    id="update-tags-input"
+                                    name="tags"
+                                    type="text"
+                                    value=""
+                                    placeholder="production www"
+                                    class="form-control" />
+
+                                <span class="help-block">
+                                    Optionally, assign tags for easy filtering.
+                                    Separate multiple tags with spaces.
+                                </span>
+                            </div>
+                        </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn btn-primary">Save</button>
+                </div>
+            </div>
+        </form>
+    </div>
+</div>
+
+<div id="update-timeout-modal" class="modal">
+    <div class="modal-dialog">
+        <form id="update-timeout-form" method="post">
+            {% csrf_token %}
+            <input type="hidden" name="timeout" id="update-timeout-timeout" />
+            <input type="hidden" name="grace" id="update-timeout-grace" />
+            <div class="modal-content">
+                <div class="modal-body">
+                    <div class="update-timeout-info text-center">
+                        <span
+                            class="update-timeout-label"
+                            data-toggle="tooltip"
+                            title="Expected time between pings.">
+                            Period
+                        </span>
+                        <span
+                            id="period-slider-value"
+                            class="update-timeout-value">
+                            1 day
+                        </span>
+                    </div>
+                    <div id="period-slider"></div>
+
+                    <div class="update-timeout-info text-center">
+                        <span
+                            class="update-timeout-label"
+                            data-toggle="tooltip"
+                            title="When check is late, how much time to wait until alert is sent">
+                            Grace Time
+                        </span>
+                        <span
+                            id="grace-slider-value"
+                            class="update-timeout-value">
+                            1 day
+                        </span>
+                    </div>
+
+                    <div id="grace-slider"></div>
+
+                    <div class="update-timeout-terms">
+                        <p>
+                            <span>Period</span>
+                            Expected time between pings.
+                        </p>
+                        <p>
+                            <span>Grace Time</span>
+                            When a check is late, how much time to wait until alert is sent.
+                        </p>
+                    </div>
+
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn btn-primary">Save</button>
+                </div>
+            </div>
+        </form>
+    </div>
+</div>
+
+<div id="remove-check-modal" class="modal">
+    <div class="modal-dialog">
+        <form id="remove-check-form" method="post">
+            {% csrf_token %}
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal">&times;</button>
+                    <h4 class="remove-check-title">Remove Check <span class="remove-check-name"></span></h4>
+                </div>
+                <div class="modal-body">
+                    <p>You are about to remove check
+                        <strong class="remove-check-name">---</strong>.
+                    </p>
+                    <p>Once it's gone there is no "undo" and you cannot get
+                    the old ping URL back.</p>
+                    <p>Are you sure?</p>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn btn-danger">Remove</button>
+                </div>
+            </div>
+        </form>
+    </div>
+</div>
+
+<div id="show-usage-modal" class="modal">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal">&times;</button>
+                <ul class="nav nav-pills" role="tablist">
+                    <li class="active">
+                        <a href="#crontab" data-toggle="tab">Crontab</a>
+                    </li>
+                    <li>
+                        <a href="#bash" data-toggle="tab">Bash</a>
+                    </li>
+                    <li>
+                        <a href="#python" data-toggle="tab">Python</a>
+                    </li>
+                    <li class="hidden-xs">
+                        <a href="#node" data-toggle="tab">Node.js</a>
+                    </li>
+                    <li class="hidden-xs">
+                        <a href="#php" data-toggle="tab">PHP</a>
+                    </li>
+                    <li class="hidden-xs">
+                        <a href="#browser" data-toggle="tab">Browser</a>
+                    </li>
+                    <li class="hidden-xs">
+                        <a href="#powershell" data-toggle="tab">PowerShell</a>
+                    </li>
+                    <li class="hidden-xs">
+                        <a href="#email" data-toggle="tab">Email</a>
+                    </li>
+                </ul>
+
+            </div>
+            <div class="modal-body">
+
+
+                <div class="tab-content">
+                    {% with ping_url="<span class='ex'></span>" %}
+                    <div role="tabpanel" class="tab-pane active" id="crontab">
+                        {% include "front/snippets/crontab.html" %}
+                    </div>
+                    <div role="tabpanel" class="tab-pane" id="bash">
+                        {% include "front/snippets/bash.html" %}
+                    </div>
+                    <div role="tabpanel" class="tab-pane" id="python">
+                        {% include "front/snippets/python.html" %}
+                    </div>
+                    <div role="tabpanel" class="tab-pane" id="node">
+                        {% include "front/snippets/node.html" %}
+                    </div>
+                    <div role="tabpanel" class="tab-pane" id="php">
+                        {% include "front/snippets/php.html" %}
+                    </div>
+                    <div class="tab-pane" id="browser">
+                        {% include "front/snippets/browser.html" %}
+                    </div>
+                    <div class="tab-pane" id="powershell">
+                        {% include "front/snippets/powershell.html" %}
+                    </div>
+                    <div class="tab-pane" id="email">
+                            As an alternative to HTTP/HTTPS requests,
+                            you can "ping" this check by sending an
+                            email message to
+                            <div class="email-address">
+                                <code class="em"></code>
+                            </div>
+                    </div>
+                    {% endwith %}
+                </div>
+
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal">Got It!</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<form id="pause-form" method="post">
+    {% csrf_token %}
+</form>
+
+{% endblock %}
+
+{% block scripts %}
+{% compress js %}
+<script src="{% static 'js/jquery-2.1.4.min.js' %}"></script>
+<script src="{% static 'js/bootstrap.min.js' %}"></script>
+<script src="{% static 'js/nouislider.min.js' %}"></script>
+<script src="{% static 'js/clipboard.min.js' %}"></script>
+<script src="{% static 'js/checks.js' %}"></script>
+{% endcompress %}
+{% endblock %}


### PR DESCRIPTION
**What does this PR do?**
An unresolved tab has been added to the user's dashboard. When a user clicks on this tab they can see a list of their checks that are failing. A screenshot of this is shown below.

<img width="1280" alt="screen shot 2018-06-06 at 18 42 00" src="https://user-images.githubusercontent.com/25581395/41096206-92d49822-6a5c-11e8-8f5e-163e24ee36da.png">

**Description of Task to be completed?**
Apart from the email notifications, the user should also have a separate dashboard view of their failed jobs.

**How should this be manually tested?**
- Clone the repo, ```cd``` into the project and run ```./manage.py runserver```. 
- Navigate to the url provided by the development server (usually ```localhost```) using a browser.
- Create an account or log in
- Create a new check and with a suitable ```period``` and ```grace```
- Ping the url provided.
- Wait for the check to fail.
- When the check fails, it should appear in the unresolved tab, with a badge indicating the number of failed checks

**What are relevant pivotal tracker stories?**
[#157694799](https://www.pivotaltracker.com/story/show/157694799)